### PR TITLE
Add a space to iOS 11

### DIFF
--- a/_pages/en_US/home.txt
+++ b/_pages/en_US/home.txt
@@ -1,6 +1,6 @@
 ---
 layout: splash
-title: "iOS11 JB Guide" #
+title: "iOS 11 JB Guide" #
 header:
   overlay_color: "#5e616c" #
   overlay_image: /images/home-page-feature.png


### PR DESCRIPTION
iOS versions mentioned without a space between iOS and the number tend to appear on illegitimate sites. Having it spaced correctly might help keep users on the page